### PR TITLE
Fix: Cannot set property which has only a getter

### DIFF
--- a/src/proxy.js
+++ b/src/proxy.js
@@ -6,6 +6,7 @@ import {
 	is,
 	isDraftable,
 	isDraft,
+	ownKeys
 	shallowCopy,
 	DRAFT_STATE
 } from "./common"
@@ -130,6 +131,10 @@ function get(state, prop) {
 		// Store drafts on the copy (when one exists).
 		drafts = state.copy
 	}
+	
+	if (!ownKeys(state.base).includes(prop)) {
+    	        return value
+        } 
 
 	return (drafts[prop] = createProxy(value, state))
 }


### PR DESCRIPTION
When a method of a Class makes changes to a cloned copy of a getter property, which type is an array, the property is included in the drafts, causing the TypeError: Cannot set property 'propName' of #<Class> which has only a getter. For example:
```javascript
class State {
  [immerable] = true
  word1 = 'bar'
  word2 = 'foo'
  get chars() {
    return this.word1.split('')
  }
  setWord2() {
    let mix = [...this.chars].slice()
    // The line below changes a cloned copy of this.chars
    mix[2] = 'z'
    this.word2 = mix.join('')
  }
}

const state = new State()

test('should allow getter array', () => {
  expect(state.word1).toEqual('bar')
  expect(state.chars).toEqual(['b', 'a', 'r'])
  const newState = produce(state, d => d.setWord2()) // TypeError: Cannot set property chars of #<State> which has only a getter
  expect(newState.word2).toEqual('baz')
})
```

This PR fixes it, checking with `ownKeys` if the property exists in the state.base, before creating the proxy. If the property doesn't exist, it returns the value.

https://codesandbox.io/s/great-colden-1py9k